### PR TITLE
Fixed missing `timeout` argument on iOS

### DIFF
--- a/ios/Classes/GBPingHelper.swift
+++ b/ios/Classes/GBPingHelper.swift
@@ -10,7 +10,7 @@ public class GBPingHelper: NSObject {
   private var ping: GBPing?
   private let delegate = PingDelegate()
 
-  func start(withHost host: String, ipv4: Bool, ipv6: Bool, count: UInt, interval: TimeInterval, handler: @escaping Handler) {
+  func start(withHost host: String, ipv4: Bool, ipv6: Bool, count: UInt, interval: TimeInterval, timeout: TimeInterval, handler: @escaping Handler) {
     ping?.stop()
     ping = GBPing()
     guard let ping = ping else {
@@ -21,6 +21,7 @@ public class GBPingHelper: NSObject {
     ping.useIpv6 = ipv6
     ping.count = count
     ping.pingPeriod = interval
+    ping.timeout = timeout
 
     delegate.handler = handler
     ping.delegate = delegate

--- a/ios/Classes/SwiftFlutterIcmpPingPlugin.swift
+++ b/ios/Classes/SwiftFlutterIcmpPingPlugin.swift
@@ -36,8 +36,9 @@ public class SwiftFlutterIcmpPingPlugin: NSObject, FlutterPlugin, FlutterStreamH
       }
       let count = arguments["count"] as? UInt ?? 0
       let interval = arguments["interval"] as? TimeInterval ?? 1
+      let timeout = arguments["timeout"] as? TimeInterval ?? 2
       let ipv6 = arguments["ipv6"] as? Bool ?? false
-      ping?.start(withHost: host, ipv4: !ipv6, ipv6: ipv6, count: count, interval: interval) { ret in
+      ping?.start(withHost: host, ipv4: !ipv6, ipv6: ipv6, count: count, interval: interval, timeout: timeout) { ret in
         if let sink = self.eventSink {
           sink(ret.merging(["hash": hash]) {(_,new) in new})
         }


### PR DESCRIPTION
`timeout` argument wasn't forwarded to iOS native code and default value of 2s was always used instead. I haven't check the Android version yet.