### PR TITLE
methodCh.invokeMethod moved below to eventCh broadcast stream

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -101,7 +101,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -115,7 +115,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,7 +127,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -162,21 +162,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.2 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.5.0"

--- a/lib/src/ping_ios.dart
+++ b/lib/src/ping_ios.dart
@@ -19,15 +19,6 @@ class PingiOS extends BasePing {
 
   @override
   Future<void> onListen() async {
-    await _methodCh.invokeMethod('start', {
-      'hash': hashCode,
-      'host': host,
-      'count': count,
-      'interval': interval,
-      'timeout': timeout,
-      'ipv6': ipv6,
-      'ttl': ttl,
-    });
     controllers[hashCode] = controller;
     _eventCh
         .receiveBroadcastStream()
@@ -43,6 +34,15 @@ class PingiOS extends BasePing {
         }
       });
       controllers.removeWhere((key, controller) => controller.isClosed);
+    });
+    await _methodCh.invokeMethod('start', {
+      'hash': hashCode,
+      'host': host,
+      'count': count,
+      'interval': interval,
+      'timeout': timeout,
+      'ipv6': ipv6,
+      'ttl': ttl,
     });
   }
 


### PR DESCRIPTION
Bug description:
In first opening the app, there is no event coming from event channel. But it must come, I moved methodChannel start invoke method line to below eventChannel broadcast stream and now the event coming.

How to reproduce:
1- Turn off wifi and cellular.
2- And try to ping any url.
3- Now start the app, you will not receive any event from Ping(...).stream.listen; 
4- Hot restart the app, now your code will work and you will get event unknownHost

iPhone 7 Plus, iOS 15.5, Flutter 3.0.2 Stable