### PR TITLE
Fix crash issue under multi threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.3
-- fix occasional GBPing get hostAddressFamily crash issue
+- fix GBPing occasional crash under multi-threading.
+- 
 
 ## 3.1.2
 - support iOS native call GBPing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+- fix occasional GBPing get hostAddressFamily crash issue
+
 ## 3.1.2
 - support iOS native call GBPing
 

--- a/ios/Classes/GBPing/GBPing.m
+++ b/ios/Classes/GBPing/GBPing.m
@@ -933,12 +933,13 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen)
 }
 
 - (sa_family_t)hostAddressFamily {
-    sa_family_t     result;
-    
-    result = AF_UNSPEC;
-    if ( (self.hostAddress != nil) && (self.hostAddress.length >= sizeof(struct sockaddr)) ) {
-        result = ((const struct sockaddr *) self.hostAddress.bytes)->sa_family;
+    sa_family_t result = AF_UNSPEC;
+    // Save a reference to a local variable, avoid crash when hostAddress is release by other thread.
+    NSData *hostAddress = self.hostAddress; 
+    if (hostAddress != nil && hostAddress.length >= sizeof(struct sockaddr)) {
+        result = ((const struct sockaddr *)hostAddress.bytes)->sa_family;
     }
+    
     return result;
 }
 

--- a/ios/Classes/GBPing/GBPing.m
+++ b/ios/Classes/GBPing/GBPing.m
@@ -217,8 +217,10 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
     
     //set up data structs
     self.nextSequenceNumber = 0;
-    self.pendingPings = [[NSMutableDictionary alloc] init];
-    self.timeoutTimers = [[NSMutableDictionary alloc] init];
+    @synchronized (self) {
+        self.pendingPings = [[NSMutableDictionary alloc] init];
+        self.timeoutTimers = [[NSMutableDictionary alloc] init];
+    }
     
     dispatch_async(self.setupQueue, ^{
         CFStreamError streamError;
@@ -982,8 +984,10 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen)
 -(void)dealloc {
     self.delegate = nil;
     self.host = nil;
-    self.timeoutTimers = nil;
-    self.pendingPings = nil;
+    @synchronized (self) {
+        self.timeoutTimers = nil;
+        self.pendingPings = nil;
+    }
     self.hostAddress = nil;
     
     //clean up socket to be sure

--- a/ios/Classes/GBPing/GBPing.m
+++ b/ios/Classes/GBPing/GBPing.m
@@ -430,7 +430,10 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
             
             NSUInteger seqNo = (NSUInteger)OSSwapBigToHostInt16(headerPointer->sequenceNumber);
             NSNumber *key = @(seqNo);
-            GBPingSummary *pingSummary = [(GBPingSummary *)self.pendingPings[key] copy];
+            GBPingSummary *pingSummary;
+            @synchronized (self) {
+                pingSummary = [(GBPingSummary *)self.pendingPings[key] copy];
+            }
 
             if (pingSummary) {
                 if ([self isValidPingResponsePacket:packet]) {
@@ -447,9 +450,9 @@ static NSTimeInterval const kDefaultTimeout =           2.0;
                     pingSummary.status = GBPingStatusSuccess;
 
                     //invalidate the timeouttimer
-                    NSTimer *timer = self.timeoutTimers[key];
-                    [timer invalidate];
                     @synchronized (self) {
+                        NSTimer *timer = self.timeoutTimers[key];
+                        [timer invalidate];
                         [self.timeoutTimers removeObjectForKey:key];
                     }
                     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_icmp_ping
 description: Flutter plugin that sends ICMP ECHO_REQUEST to network hosts.
-version: 3.1.2
+version: 3.1.3
 homepage: https://github.com/zuvola/flutter_icmp_ping
 
 environment:


### PR DESCRIPTION
- Under multi-threading, `NSMutableDictionary` modifying is not safe and requires locking.
- At OC language, released variables using `->` will cause a crash.